### PR TITLE
Fix logout link in navbar

### DIFF
--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -17,10 +17,7 @@ if (session_status() === PHP_SESSION_NONE) {
     <div>
     
 <?php if (isset($_SESSION['Id_utilisateur'])): ?>
-     <form method="POST" action="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/accueil.php">
-        <input type="submit" value="Se Déconnecter" class="logout-button">
-        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/logout.php" class="logout-button">Se Déconnecter</a>
-     </form>
+    <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/logout.php" class="logout-button">Se Déconnecter</a>
 <?php else: ?>
     <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php" class="btn-connexion">Se Connecter</a>
     <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/inscription.php" class="btn-inscription">S'inscrire</a>


### PR DESCRIPTION
## Summary
- simplify logout handling in the navbar so clicking 'Se Déconnecter' redirects to logout.php

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a9e18cd408330b0309469475a5ed9