### PR TITLE
Fix login for hashed passwords

### DIFF
--- a/controleur(PHP)/traitement_login.php
+++ b/controleur(PHP)/traitement_login.php
@@ -8,25 +8,33 @@ if (session_status() === PHP_SESSION_NONE) {
 include $_SERVER['DOCUMENT_ROOT'] . "/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/admin/db.php" ;
 
 if($_SERVER["REQUEST_METHOD"] == "POST") {
-    $mail = $_POST["mail"];
-    $mdp = $_POST["mdp"];
+    $mail = $_POST["mail"] ?? '';
+    $mdp  = $_POST["mdp"]  ?? '';
 }
 
-$check_all = $connexion->prepare(
-    "SELECT Id_utilisateur, isAdmin FROM utilisateur WHERE mail = ? AND mot_de_passe = ?"
+// Retrieve user info by email only. We'll verify the password manually so that
+// both hashed and legacy plain text passwords are supported.
+$stmt = $connexion->prepare(
+    "SELECT Id_utilisateur, mot_de_passe, isAdmin FROM utilisateur WHERE mail = ?"
 );
-$check_all->bind_param("ss", $mail, $mdp);
-$check_all->execute();
-$result = $check_all->get_result();
+$stmt->bind_param("s", $mail);
+$stmt->execute();
+$result = $stmt->get_result();
+$row = $result->fetch_assoc();
 
-foreach ($result as $row) {
-    $_SESSION['Id_utilisateur'] = $row['Id_utilisateur'];
-    $_SESSION['isAdmin'] = (int) $row['isAdmin'];
+$authenticated = false;
+if ($row) {
+    // Verify using password_verify for hashed passwords. Fallback to direct
+    // comparison for older accounts stored in plain text.
+    if (password_verify($mdp, $row['mot_de_passe']) || $mdp === $row['mot_de_passe']) {
+        $_SESSION['Id_utilisateur'] = $row['Id_utilisateur'];
+        $_SESSION['isAdmin'] = (int) $row['isAdmin'];
+        $authenticated = true;
+    }
 }
+$stmt->close();
 
-
-
-if($result->num_rows > 0 ){
+if($authenticated){
     echo"<script>alert('Connexion réussie !');window.location.href = '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/accueil.php';</script>";
 }else{
     echo"<script>alert('Mail et/ou mot de passe incorrecte !');window.location.href = '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php';</script>";


### PR DESCRIPTION
## Summary
- verify passwords with `password_verify`
- support legacy plaintext passwords when logging in

## Testing
- `php -l controleur(PHP)/traitement_login.php`
- `php -l controleur(PHP)/traitement_inscription.php`


------
https://chatgpt.com/codex/tasks/task_e_684ab3be14908330a651defacaeedcf7