### PR TITLE
Add terrain reservation system

### DIFF
--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -12,6 +12,7 @@ if (session_status() === PHP_SESSION_NONE) {
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/resa2.php">Réserver un Terrain</a>
         <?php if (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1): ?>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/utilisateurs.php">Gérer les utilisateurs</a>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/reservations.php">Gérer les réservations</a>
         <?php endif; ?>
         <a href="quisommesnous.php">Qui sommes-nous ?</a>
         <a href="contact.php">Contacter le Créateur</a>

--- a/modele(SQL)/commun/reservation.php
+++ b/modele(SQL)/commun/reservation.php
@@ -1,0 +1,36 @@
+<?php
+function getDbConnection() {
+    $servername = 'localhost';
+    $username = 'root';
+    $password = '';
+    $dbname = 'tablepetanque';
+    $pdo = new PDO("mysql:host=$servername;dbname=$dbname;charset=utf8", $username, $password);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+function isTerrainAvailable(PDO $pdo, $terrainId, $startDate, $endDate) {
+    $sql = 'SELECT COUNT(*) FROM reservation WHERE Id_Terrain = :terrain AND date_debut < :end AND date_fin > :start';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([
+        ':terrain' => $terrainId,
+        ':end' => $endDate,
+        ':start' => $startDate
+    ]);
+    return $stmt->fetchColumn() == 0;
+}
+
+function createReservation(PDO $pdo, $terrainId, $userId, $startDate, $endDate, $nbrUtil) {
+    $sql = 'INSERT INTO reservation (Id_reservation, date_debut, date_fin, nbr_util, Id_Terrain, Id_utilisateur)
+            VALUES (:id, :start, :end, :nbr, :terrain, :user)';
+    $stmt = $pdo->prepare($sql);
+    return $stmt->execute([
+        ':id' => uniqid(),
+        ':start' => $startDate,
+        ':end' => $endDate,
+        ':nbr' => $nbrUtil,
+        ':terrain' => $terrainId,
+        ':user' => $userId
+    ]);
+}
+?>

--- a/vue(HTML)/admin/reservations.php
+++ b/vue(HTML)/admin/reservations.php
@@ -1,0 +1,62 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (empty($_SESSION['isAdmin']) || $_SESSION['isAdmin'] != 1) {
+    header('Location: /E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php');
+    exit();
+}
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
+$pdo = getDbConnection();
+
+if (isset($_GET['delete'])) {
+    $stmt = $pdo->prepare('DELETE FROM reservation WHERE Id_reservation = ?');
+    $stmt->execute([$_GET['delete']]);
+    header('Location: reservations.php');
+    exit();
+}
+
+$sql = 'SELECT r.*, t.nom_terrain, u.nom, u.Prenom FROM reservation r
+        JOIN terrain t ON r.Id_Terrain = t.Id_Terrain
+        JOIN utilisateur u ON r.Id_utilisateur = u.Id_utilisateur';
+$reservations = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestion des réservations</title>
+    <link rel="stylesheet" type="text/css" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<h1>Gestion des réservations</h1>
+<table>
+    <thead>
+        <tr>
+            <th>Terrain</th>
+            <th>Du</th>
+            <th>Au</th>
+            <th>Utilisateur</th>
+            <th>Nb Util.</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($reservations as $r): ?>
+        <tr>
+            <td><?= htmlspecialchars($r['nom_terrain']) ?></td>
+            <td><?= htmlspecialchars($r['date_debut']) ?></td>
+            <td><?= htmlspecialchars($r['date_fin']) ?></td>
+            <td><?= htmlspecialchars($r['nom'] . ' ' . $r['Prenom']) ?></td>
+            <td><?= htmlspecialchars($r['nbr_util']) ?></td>
+            <td><a href="reservations.php?delete=<?= $r['Id_reservation'] ?>" onclick="return confirm('Supprimer ?');">Supprimer</a></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+</body>
+<footer>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</footer>
+</html>

--- a/vue(HTML)/commun/resa2.php
+++ b/vue(HTML)/commun/resa2.php
@@ -111,6 +111,7 @@ try {
                 <th>Note</th>
                 <th>Latitude</th>
                 <th>Longitude</th>
+                <th>Réserver</th>
                 <?php if (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1): ?>
                     <th>Actions</th>
                 <?php endif; ?>
@@ -126,6 +127,7 @@ try {
                     <td><?= htmlspecialchars($terrain['note']) ?></td>
                     <td><?= htmlspecialchars($terrain['latitude']) ?></td>
                     <td><?= htmlspecialchars($terrain['longitude']) ?></td>
+                    <td><a href="reserver.php?id=<?= $terrain['Id_Terrain'] ?>">Réserver</a></td>
                     <?php if (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1): ?>
                     <td>
                         <a href="modifier.php?id=<?= $terrain['Id_Terrain'] ?>">Modifier</a> |

--- a/vue(HTML)/commun/reserver.php
+++ b/vue(HTML)/commun/reserver.php
@@ -1,0 +1,67 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (empty($_SESSION['Id_utilisateur'])) {
+    header('Location: login.php');
+    exit();
+}
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
+$pdo = getDbConnection();
+
+$terrainId = $_GET['id'] ?? '';
+if (!$terrainId) {
+    echo 'Aucun terrain sélectionné.';
+    exit();
+}
+
+// Fetch terrain details
+$stmt = $pdo->prepare('SELECT * FROM terrain WHERE Id_Terrain = ?');
+$stmt->execute([$terrainId]);
+$terrain = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$terrain) {
+    echo 'Terrain introuvable';
+    exit();
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $dateDebut = $_POST['date_debut'] ?? '';
+    $dateFin = $_POST['date_fin'] ?? '';
+    $nbrUtil = (int)($_POST['nbr_util'] ?? 1);
+
+    if (strtotime($dateFin) <= strtotime($dateDebut)) {
+        $message = 'La date de fin doit être supérieure à la date de début';
+    } elseif (!isTerrainAvailable($pdo, $terrainId, $dateDebut, $dateFin)) {
+        $message = 'Ce terrain est déjà réservé pour cette période';
+    } else {
+        createReservation($pdo, $terrainId, $_SESSION['Id_utilisateur'], $dateDebut, $dateFin, $nbrUtil);
+        $message = 'Réservation enregistrée !';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Réserver</title>
+    <link rel="stylesheet" type="text/css" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<h1>Réserver le terrain: <?= htmlspecialchars($terrain['nom_terrain']) ?></h1>
+<?php if ($message) echo '<p>' . htmlspecialchars($message) . '</p>'; ?>
+<form method="POST">
+    <label for="date_debut">Date de début</label>
+    <input type="datetime-local" id="date_debut" name="date_debut" required><br>
+    <label for="date_fin">Date de fin</label>
+    <input type="datetime-local" id="date_fin" name="date_fin" required><br>
+    <label for="nbr_util">Nombre d\'utilisateurs</label>
+    <input type="number" id="nbr_util" name="nbr_util" value="1" min="1" required><br>
+    <button type="submit">Réserver</button>
+</form>
+</body>
+<footer>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</footer>
+</html>


### PR DESCRIPTION
## Summary
- create reservation helpers and basic DB access
- allow users to reserve a terrain
- provide admin interface to see and delete reservations
- add reservation links in navigation and terrain list

## Testing
- `php -l modele(SQL)/commun/reservation.php`
- `php -l vue(HTML)/commun/reserver.php`
- `php -l vue(HTML)/admin/reservations.php`
- `php -l vue(HTML)/commun/resa2.php`
- `php -l include(redondance)/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_684ab72de1b08330a6d1a434aaa392f5