### PR TITLE
Add user profile and reservations history pages

### DIFF
--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -10,6 +10,10 @@ if (session_status() === PHP_SESSION_NONE) {
     <div class="links">
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/accueil.php">Accueil</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/resa2.php">Réserver un Terrain</a>
+        <?php if (!empty($_SESSION['Id_utilisateur']) && empty($_SESSION['isAdmin'])): ?>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/profil.php">Mon Profil</a>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/historique.php">Mes Réservations</a>
+        <?php endif; ?>
         <?php if (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1): ?>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/utilisateurs.php">Gérer les utilisateurs</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/reservations.php">Gérer les réservations</a>

--- a/modele(SQL)/commun/reservation.php
+++ b/modele(SQL)/commun/reservation.php
@@ -33,4 +33,23 @@ function createReservation(PDO $pdo, $terrainId, $userId, $startDate, $endDate, 
         ':user' => $userId
     ]);
 }
+
+/**
+ * Retrieve all reservations for a specific user.
+ *
+ * @param PDO $pdo       Database connection
+ * @param int $userId    User identifier
+ *
+ * @return array         List of reservations with terrain information
+ */
+function getReservationsForUser(PDO $pdo, $userId) {
+    $sql = 'SELECT r.*, t.nom_terrain
+            FROM reservation r
+            JOIN terrain t ON r.Id_Terrain = t.Id_Terrain
+            WHERE r.Id_utilisateur = :user
+            ORDER BY r.date_debut DESC';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':user' => $userId]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
 ?>

--- a/vue(HTML)/commun/historique.php
+++ b/vue(HTML)/commun/historique.php
@@ -1,0 +1,55 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+// Restrict access to logged in non-admin users
+if (empty($_SESSION['Id_utilisateur']) || (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1)) {
+    header('Location: login.php');
+    exit();
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
+$pdo = getDbConnection();
+
+$reservations = getReservationsForUser($pdo, $_SESSION['Id_utilisateur']);
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Mes Réservations</title>
+    <base href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/">
+    <link rel="stylesheet" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<div class="container">
+    <h1>Mes Réservations</h1>
+    <div class="card">
+        <table>
+            <thead>
+                <tr>
+                    <th>Terrain</th>
+                    <th>Du</th>
+                    <th>Au</th>
+                    <th>Nb Util.</th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($reservations as $r): ?>
+                <tr>
+                    <td><?= htmlspecialchars($r['nom_terrain']) ?></td>
+                    <td><?= htmlspecialchars($r['date_debut']) ?></td>
+                    <td><?= htmlspecialchars($r['date_fin']) ?></td>
+                    <td><?= htmlspecialchars($r['nbr_util']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+<footer>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</footer>
+</html>

--- a/vue(HTML)/commun/profil.php
+++ b/vue(HTML)/commun/profil.php
@@ -1,0 +1,44 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+// Restrict access to logged in non-admin users
+if (empty($_SESSION['Id_utilisateur']) || (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1)) {
+    header('Location: login.php');
+    exit();
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
+$pdo = getDbConnection();
+
+$stmt = $pdo->prepare('SELECT nom, Prenom, mail FROM utilisateur WHERE Id_utilisateur = ?');
+$stmt->execute([$_SESSION['Id_utilisateur']]);
+$user = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$user) {
+    echo 'Utilisateur introuvable';
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Mon Profil</title>
+    <base href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/">
+    <link rel="stylesheet" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<div class="container">
+    <h1>Mon Profil</h1>
+    <div class="card">
+        <p><strong>Nom :</strong> <?= htmlspecialchars($user['nom']) ?></p>
+        <p><strong>Prénom :</strong> <?= htmlspecialchars($user['Prenom']) ?></p>
+        <p><strong>Email :</strong> <?= htmlspecialchars($user['mail']) ?></p>
+    </div>
+</div>
+</body>
+<footer>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</footer>
+</html>


### PR DESCRIPTION
## Summary
- add `getReservationsForUser` in reservations model
- create profile page for logged-in users
- create history page listing user reservations
- link profile and history from navbar when non-admin users are logged in

## Testing
- `php -l vue(HTML)/commun/profil.php`
- `php -l vue(HTML)/commun/historique.php`
- `php -l include(redondance)/navbar.php`
- `php -l modele(SQL)/commun/reservation.php`


------
https://chatgpt.com/codex/tasks/task_e_684aca9fdae88330829f5f435db20635