### PR TITLE
Allow non-admin reservation cancellation

### DIFF
--- a/modele(SQL)/commun/reservation.php
+++ b/modele(SQL)/commun/reservation.php
@@ -52,4 +52,18 @@ function getReservationsForUser(PDO $pdo, $userId) {
     $stmt->execute([':user' => $userId]);
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
+
+/**
+ * Delete a reservation belonging to a specific user.
+ *
+ * @param PDO    $pdo  Database connection
+ * @param string $id   Reservation identifier
+ * @param int    $user User identifier
+ *
+ * @return bool        True on success
+ */
+function deleteReservation(PDO $pdo, $id, $user) {
+    $stmt = $pdo->prepare('DELETE FROM reservation WHERE Id_reservation = :id AND Id_utilisateur = :user');
+    return $stmt->execute([':id' => $id, ':user' => $user]);
+}
 ?>

--- a/vue(HTML)/commun/historique.php
+++ b/vue(HTML)/commun/historique.php
@@ -11,7 +11,15 @@ if (empty($_SESSION['Id_utilisateur']) || (!empty($_SESSION['isAdmin']) && $_SES
 require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
 $pdo = getDbConnection();
 
-$reservations = getReservationsForUser($pdo, $_SESSION['Id_utilisateur']);
+$userId = $_SESSION['Id_utilisateur'];
+// Handle reservation cancellation
+if (isset($_GET['delete'])) {
+    deleteReservation($pdo, $_GET['delete'], $userId);
+    header('Location: historique.php');
+    exit();
+}
+
+$reservations = getReservationsForUser($pdo, $userId);
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -33,6 +41,7 @@ $reservations = getReservationsForUser($pdo, $_SESSION['Id_utilisateur']);
                     <th>Du</th>
                     <th>Au</th>
                     <th>Nb Util.</th>
+                    <th>Action</th>
                 </tr>
             </thead>
             <tbody>
@@ -42,6 +51,9 @@ $reservations = getReservationsForUser($pdo, $_SESSION['Id_utilisateur']);
                     <td><?= htmlspecialchars($r['date_debut']) ?></td>
                     <td><?= htmlspecialchars($r['date_fin']) ?></td>
                     <td><?= htmlspecialchars($r['nbr_util']) ?></td>
+                    <td>
+                        <a class="button" href="vue(HTML)/commun/historique.php?delete=<?= urlencode($r['Id_reservation']) ?>" onclick="return confirm('Annuler cette réservation ?');">Annuler</a>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>


### PR DESCRIPTION
## Summary
- let users cancel their reservation from `historique.php`
- add new `deleteReservation` helper in the reservation model

## Testing
- `php -l modele(SQL)/commun/reservation.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acf9050408330af0e01c5251215e3