### PR TITLE
Refactor stats page

### DIFF
--- a/modele(SQL)/admin/statistiques.php
+++ b/modele(SQL)/admin/statistiques.php
@@ -1,0 +1,60 @@
+<?php
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/db.php';
+
+/**
+ * Retrieve the number of users registered.
+ */
+function fetchTotalUsers(PDO $pdo): int {
+    return (int) $pdo->query('SELECT COUNT(*) FROM utilisateur')->fetchColumn();
+}
+
+/**
+ * Retrieve the number of administrators.
+ */
+function fetchTotalAdmins(PDO $pdo): int {
+    return (int) $pdo->query('SELECT COUNT(*) FROM utilisateur WHERE isAdmin = 1')->fetchColumn();
+}
+
+/**
+ * Retrieve the number of terrains.
+ */
+function fetchTotalTerrains(PDO $pdo): int {
+    return (int) $pdo->query('SELECT COUNT(*) FROM terrain')->fetchColumn();
+}
+
+/**
+ * Retrieve how many terrains have at least one reservation.
+ */
+function fetchReservedTerrains(PDO $pdo): int {
+    return (int) $pdo->query('SELECT COUNT(DISTINCT Id_Terrain) FROM reservation')->fetchColumn();
+}
+
+/**
+ * Retrieve the list of most represented cities ordered by user count.
+ *
+ * @param PDO $pdo       Database connection
+ * @param int $limit     Maximum number of cities to retrieve
+ *
+ * @return array{ville:string,nbr:int}[]
+ */
+function fetchTopCities(PDO $pdo, int $limit = 5): array {
+    $stmt = $pdo->query('SELECT ville, COUNT(*) AS nbr FROM utilisateur GROUP BY ville ORDER BY nbr DESC LIMIT ' . (int) $limit);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+/**
+ * Retrieve the users who made the most reservations.
+ *
+ * @param PDO $pdo   Database connection
+ * @param int $limit Maximum number of users
+ */
+function fetchTopReservers(PDO $pdo, int $limit = 5): array {
+    $sql = 'SELECT u.nom, u.Prenom, COUNT(r.Id_reservation) AS nbr
+            FROM utilisateur u
+            LEFT JOIN reservation r ON u.Id_utilisateur = r.Id_utilisateur
+            GROUP BY u.Id_utilisateur
+            ORDER BY nbr DESC
+            LIMIT ' . (int) $limit;
+    $stmt = $pdo->query($sql);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/vue(HTML)/admin/statistiques.php
+++ b/vue(HTML)/admin/statistiques.php
@@ -6,22 +6,20 @@ if (empty($_SESSION['isAdmin']) || $_SESSION['isAdmin'] != 1) {
     header('Location: /E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php');
     exit();
 }
-require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/db.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/admin/statistiques.php';
 $pdo = getPDO();
 
-$totalUsers = $pdo->query('SELECT COUNT(*) FROM utilisateur')->fetchColumn();
-$totalAdmins = $pdo->query('SELECT COUNT(*) FROM utilisateur WHERE isAdmin = 1')->fetchColumn();
+// Fetch all needed statistics through dedicated helper functions
+$totalUsers      = fetchTotalUsers($pdo);
+$totalAdmins     = fetchTotalAdmins($pdo);
 
 // Terrains statistics
-$totalTerrains = $pdo->query('SELECT COUNT(*) FROM terrain')->fetchColumn();
-$reservedTerrains = $pdo->query('SELECT COUNT(DISTINCT Id_Terrain) FROM reservation')->fetchColumn();
-$percentReserved = $totalTerrains > 0 ? round($reservedTerrains / $totalTerrains * 100, 2) : 0;
+$totalTerrains   = fetchTotalTerrains($pdo);
+$reservedTerrains = fetchReservedTerrains($pdo);
+$percentReserved  = $totalTerrains > 0 ? round($reservedTerrains / $totalTerrains * 100, 2) : 0;
 
-$citiesStmt = $pdo->query('SELECT ville, COUNT(*) AS nbr FROM utilisateur GROUP BY ville ORDER BY nbr DESC LIMIT 5');
-$cities = $citiesStmt->fetchAll(PDO::FETCH_ASSOC);
-
-$resStmt = $pdo->query('SELECT u.nom, u.Prenom, COUNT(r.Id_reservation) AS nbr FROM utilisateur u LEFT JOIN reservation r ON u.Id_utilisateur = r.Id_utilisateur GROUP BY u.Id_utilisateur ORDER BY nbr DESC LIMIT 5');
-$reservers = $resStmt->fetchAll(PDO::FETCH_ASSOC);
+$cities     = fetchTopCities($pdo, 5);
+$reservers  = fetchTopReservers($pdo, 5);
 ?>
 
 


### PR DESCRIPTION
## Summary
- add admin model helper functions for statistics
- load those helpers from the admin statistics view

## Testing
- `php -l modele(SQL)/admin/statistiques.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fc72b42e48330b2a0a26cf0010e90