### PR TITLE
Add terrain occupancy rate helper

### DIFF
--- a/modele(SQL)/admin/statistiques.php
+++ b/modele(SQL)/admin/statistiques.php
@@ -24,6 +24,20 @@ function fetchReservedTerrains(PDO $pdo): int {
 }
 
 /**
+ * Calculate the occupancy rate of the terrains.
+ *
+ * @return float Ratio of reserved terrains to total terrains
+ */
+function tauxOccupationTerrain(PDO $pdo): float {
+    $total    = fetchTotalTerrains($pdo);
+    if ($total === 0) {
+        return 0.0;
+    }
+    $reserved = fetchReservedTerrains($pdo);
+    return $reserved / $total;
+}
+
+/**
 
  *
  * @param PDO $pdo       

--- a/vue(HTML)/admin/statistiques.php
+++ b/vue(HTML)/admin/statistiques.php
@@ -14,9 +14,10 @@ $totalUsers      = fetchTotalUsers($pdo);
 $totalAdmins     = fetchTotalAdmins($pdo);
 
 // Terrains statistics
-$totalTerrains   = fetchTotalTerrains($pdo);
+$totalTerrains    = fetchTotalTerrains($pdo);
 $reservedTerrains = fetchReservedTerrains($pdo);
-$percentReserved  = $totalTerrains > 0 ? round($reservedTerrains / $totalTerrains * 100, 2) : 0;
+$occupationRate   = tauxOccupationTerrain($pdo);
+$percentReserved  = round($occupationRate * 100, 2);
 
 $cities     = fetchTopCities($pdo, 5);
 $reservers  = fetchTopReservers($pdo, 5);


### PR DESCRIPTION
## Summary
- add `tauxOccupationTerrain()` helper in the statistics model
- use the helper on the admin statistics page to compute percentage of occupied fields

## Testing
- `php -l modele(SQL)/admin/statistiques.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc8a4d9e48330b5b5179127755be3