### PR TITLE
Display connected user info

### DIFF
--- a/controleur(PHP)/traitement_login.php
+++ b/controleur(PHP)/traitement_login.php
@@ -16,7 +16,8 @@ if($_SERVER["REQUEST_METHOD"] == "POST") {
 // Retrieve user info by email only. We'll verify the password manually so that
 // both hashed and legacy plain text passwords are supported.
 $stmt = $pdo->prepare(
-    "SELECT Id_utilisateur, mot_de_passe, isAdmin FROM utilisateur WHERE mail = ?"
+    "SELECT Id_utilisateur, nom, Prenom, mot_de_passe, isAdmin
+     FROM utilisateur WHERE mail = ?"
 );
 $stmt->execute([$mail]);
 $row = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -27,6 +28,8 @@ if ($row) {
     // comparison for older accounts stored in plain text.
     if (password_verify($mdp, $row['mot_de_passe']) || $mdp === $row['mot_de_passe']) {
         $_SESSION['Id_utilisateur'] = $row['Id_utilisateur'];
+        $_SESSION['nom'] = $row['nom'];
+        $_SESSION['Prenom'] = $row['Prenom'];
         $_SESSION['isAdmin'] = (int) $row['isAdmin'];
         $authenticated = true;
     }

--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -27,8 +27,12 @@ if (session_status() === PHP_SESSION_NONE) {
 
     </div>
     <div>
-    
+
 <?php if (isset($_SESSION['Id_utilisateur'])): ?>
+    <span class="user-info">
+        <?= htmlspecialchars($_SESSION['Prenom'] . ' ' . $_SESSION['nom']) ?>
+        (<?= $_SESSION['isAdmin'] == 1 ? 'Admin' : 'Utilisateur' ?>)
+    </span>
     <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/logout.php" class="logout-button">Se Déconnecter</a>
 <?php else: ?>
     <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php" class="btn-connexion">Se Connecter</a>
@@ -63,11 +67,13 @@ if (session_status() === PHP_SESSION_NONE) {
     }
 
     .navbar a,
-    .logout-button {
+    .logout-button,
+    .user-info {
         color: white;
         margin: 0 15px;
         text-decoration: none;
         font-size: 17px;
+        display: inline-block;
     }
 
     .logout-button {


### PR DESCRIPTION
## Summary
- display user's name & role in the navbar
- store name information during login

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc987f0cc8330b3a8d7729dd8b7f4