### PR TITLE
Fix navbar warnings for missing session variables

### DIFF
--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -30,8 +30,8 @@ if (session_status() === PHP_SESSION_NONE) {
 
 <?php if (isset($_SESSION['Id_utilisateur'])): ?>
     <span class="user-info">
-        <?= htmlspecialchars($_SESSION['Prenom'] . ' ' . $_SESSION['nom']) ?>
-        (<?= $_SESSION['isAdmin'] == 1 ? 'Admin' : 'Utilisateur' ?>)
+        <?= htmlspecialchars(($_SESSION['Prenom'] ?? '') . ' ' . ($_SESSION['nom'] ?? '')) ?>
+        (<?= ($_SESSION['isAdmin'] ?? 0) == 1 ? 'Admin' : 'Utilisateur' ?>)
     </span>
     <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/logout.php" class="logout-button">Se Déconnecter</a>
 <?php else: ?>


### PR DESCRIPTION
## Summary
- guard against undefined session keys in the navbar

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcb0e65b08330825fd5d12c54c14e