### PR TITLE
Enable attachment sending on contact form

### DIFF
--- a/controleur(PHP)/traitement_contact.php
+++ b/controleur(PHP)/traitement_contact.php
@@ -1,0 +1,46 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $message = trim($_POST['message'] ?? '');
+
+    $to = 'ludorouge7@gmail.com';
+    $subject = 'Nouveau message depuis le formulaire de contact';
+
+    $boundary = md5(uniqid(time()));
+
+    $headers = "From: $email\r\n";
+    $headers .= "Reply-To: $email\r\n";
+    $headers .= "MIME-Version: 1.0\r\n";
+    $headers .= "Content-Type: multipart/mixed; boundary=\"$boundary\"";
+
+    $body = "--$boundary\r\n";
+    $body .= "Content-Type: text/plain; charset=utf-8\r\n\r\n";
+    $body .= "Nom: $name\n";
+    $body .= "Email: $email\n\n";
+    $body .= $message . "\n";
+
+    if (!empty($_FILES['attachment']['name'][0])) {
+        foreach ($_FILES['attachment']['tmp_name'] as $i => $tmpName) {
+            if (is_uploaded_file($tmpName)) {
+                $fileName = basename($_FILES['attachment']['name'][$i]);
+                $fileType = mime_content_type($tmpName);
+                $fileData = chunk_split(base64_encode(file_get_contents($tmpName)));
+                $body .= "--$boundary\r\n";
+                $body .= "Content-Type: $fileType; name=\"$fileName\"\r\n";
+                $body .= "Content-Disposition: attachment; filename=\"$fileName\"\r\n";
+                $body .= "Content-Transfer-Encoding: base64\r\n\r\n";
+                $body .= $fileData . "\r\n";
+            }
+        }
+    }
+
+    $body .= "--$boundary--";
+
+    if (mail($to, $subject, $body, $headers)) {
+        echo "<script>alert('Message envoyé !'); window.location.href='/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/accueil.php';</script>";
+    } else {
+        echo "<script>alert('Erreur lors de l\'envoi du message.'); window.history.back();</script>";
+    }
+}
+?>

--- a/vue(HTML)/commun/contact.php
+++ b/vue(HTML)/commun/contact.php
@@ -13,7 +13,7 @@
         <div class="card">
         <h1>Contacter le Créateur</h1>
         <p>N'hésitez pas à nous laisser un message pour toute question ou suggestion.</p>
-        <form action="traitement_contact.php" method="POST">
+        <form action="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/controleur(PHP)/traitement_contact.php" method="POST" enctype="multipart/form-data">
             <label for="name">Nom :</label>
             <input type="text" id="name" name="name" required>
 
@@ -22,6 +22,9 @@
 
             <label for="message">Message :</label>
             <textarea id="message" name="message" rows="5" required></textarea>
+
+            <label for="attachment">Pièce jointe :</label>
+            <input type="file" id="attachment" name="attachment[]" multiple>
 
             <button class="button" type="submit">Envoyer</button>
         </form>


### PR DESCRIPTION
## Summary
- allow file uploads in the contact form
- process contact requests server-side and email them with optional attachments

## Testing
- `php -l controleur(PHP)/traitement_contact.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852711718408330b631902f93ef6667