### PR TITLE
Implement basic mail management

### DIFF
--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -5,6 +5,12 @@
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/mail.php';
+$pdo = getPDO();
+$unreadCount = 0;
+if (!empty($_SESSION['Id_utilisateur'])) {
+    $unreadCount = getUnreadCount($pdo, (int)$_SESSION['Id_utilisateur']);
+}
 ?>
 <div class="navbar">
     <div class="links">
@@ -14,13 +20,14 @@ if (session_status() === PHP_SESSION_NONE) {
         <?php if (!empty($_SESSION['Id_utilisateur']) && empty($_SESSION['isAdmin'])): ?>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/resa2.php">Réserver un Terrain</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/historique.php">Mes Réservations</a>
-        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/mailbox.php">Mes Messages</a>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/mailbox.php" class="message-link">Mes Messages<?php if ($unreadCount > 0): ?><span class="notif-badge"><?= $unreadCount ?></span><?php endif; ?></a>
         <?php endif; ?>
 
         <?php if (!empty($_SESSION['isAdmin']) && $_SESSION['isAdmin'] == 1): ?>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/resa2.php">Gérer les terrains</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/utilisateurs.php">Gérer les utilisateurs</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/reservations.php">Gérer les réservations</a>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/mails.php">Gérer les mails</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/statistiques.php">Statistiques</a>
         <?php endif; ?>
 
@@ -76,6 +83,21 @@ if (session_status() === PHP_SESSION_NONE) {
         text-decoration: none;
         font-size: 17px;
         display: inline-block;
+    }
+
+    .message-link {
+        position: relative;
+    }
+
+    .notif-badge {
+        position: absolute;
+        top: -8px;
+        right: -10px;
+        background-color: red;
+        color: white;
+        border-radius: 50%;
+        padding: 2px 6px;
+        font-size: 12px;
     }
 
     .logout-button {

--- a/modele(SQL)/commun/mail.php
+++ b/modele(SQL)/commun/mail.php
@@ -25,3 +25,30 @@ function markMessageRead(PDO $pdo, int $messageId, int $userId): void {
     $stmt = $pdo->prepare('UPDATE mail SET lu = 1 WHERE Id_mail = ? AND destinataire_id = ?');
     $stmt->execute([$messageId, $userId]);
 }
+
+function deleteMessage(PDO $pdo, int $messageId): void {
+    $stmt = $pdo->prepare('DELETE FROM mail WHERE Id_mail = ?');
+    $stmt->execute([$messageId]);
+}
+
+function deleteReceivedMessage(PDO $pdo, int $messageId, int $userId): void {
+    $stmt = $pdo->prepare('DELETE FROM mail WHERE Id_mail = ? AND destinataire_id = ?');
+    $stmt->execute([$messageId, $userId]);
+}
+
+function getAllMessages(PDO $pdo): array {
+    $sql = 'SELECT m.*, 
+                   exp.Prenom AS expediteur_prenom, exp.nom AS expediteur_nom, 
+                   dest.Prenom AS destinataire_prenom, dest.nom AS destinataire_nom
+            FROM mail m
+            JOIN utilisateur exp ON m.expediteur_id = exp.Id_utilisateur
+            JOIN utilisateur dest ON m.destinataire_id = dest.Id_utilisateur
+            ORDER BY m.date_envoi DESC';
+    return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function getUnreadCount(PDO $pdo, int $userId): int {
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM mail WHERE destinataire_id = ? AND lu = 0');
+    $stmt->execute([$userId]);
+    return (int)$stmt->fetchColumn();
+}

--- a/vue(HTML)/admin/mails.php
+++ b/vue(HTML)/admin/mails.php
@@ -1,0 +1,72 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (empty($_SESSION['isAdmin']) || $_SESSION['isAdmin'] != 1) {
+    header('Location: /E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php');
+    exit();
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/mail.php';
+$pdo = getPDO();
+
+if (isset($_GET['delete'])) {
+    deleteMessage($pdo, (int)$_GET['delete']);
+    header('Location: mails.php');
+    exit();
+}
+
+$mails = getAllMessages($pdo);
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestion des mails</title>
+    <base href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/">
+    <link rel="stylesheet" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<div class="container">
+    <h1>Gestion des mails</h1>
+    <div class="card">
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Expéditeur</th>
+                    <th>Destinataire</th>
+                    <th>Sujet</th>
+                    <th>Date</th>
+                    <th>Lu</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($mails as $m): ?>
+                <tr>
+                    <td><?= htmlspecialchars($m['Id_mail']) ?></td>
+                    <td><?= htmlspecialchars($m['expediteur_prenom'] . ' ' . $m['expediteur_nom']) ?></td>
+                    <td><?= htmlspecialchars($m['destinataire_prenom'] . ' ' . $m['destinataire_nom']) ?></td>
+                    <td><?= htmlspecialchars($m['sujet'] ?? '') ?></td>
+                    <td><?= htmlspecialchars($m['date_envoi']) ?></td>
+                    <td><?= $m['lu'] ? 'Oui' : 'Non' ?></td>
+                    <td>
+                        <a class="button" href="vue(HTML)/admin/mails.php?delete=<?= $m['Id_mail'] ?>" onclick="return confirm('Supprimer ?');">Supprimer</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan="7"><?= nl2br(htmlspecialchars($m['corps'])) ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+<footer>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</footer>
+</html>

--- a/vue(HTML)/commun/mailbox.php
+++ b/vue(HTML)/commun/mailbox.php
@@ -18,6 +18,12 @@ if (isset($_GET['read'])) {
     exit();
 }
 
+if (isset($_GET['delete'])) {
+    deleteReceivedMessage($pdo, (int)$_GET['delete'], $userId);
+    header('Location: mailbox.php');
+    exit();
+}
+
 // Send message
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $dest = (int)($_POST['destinataire'] ?? 0);
@@ -54,6 +60,7 @@ $users = getAllUsers($pdo);
                     <th>Sujet</th>
                     <th>Date</th>
                     <th>Lu</th>
+                    <th>Action</th>
                 </tr>
             </thead>
             <tbody>
@@ -68,9 +75,12 @@ $users = getAllUsers($pdo);
                             <a href="vue(HTML)/commun/mailbox.php?read=<?= $m['Id_mail'] ?>">Marquer comme lu</a>
                         <?php endif; ?>
                     </td>
+                    <td>
+                        <a href="vue(HTML)/commun/mailbox.php?delete=<?= $m['Id_mail'] ?>" onclick="return confirm('Supprimer ?');">Supprimer</a>
+                    </td>
                 </tr>
                 <tr>
-                    <td colspan="4"><?= nl2br(htmlspecialchars($m['corps'])) ?></td>
+                    <td colspan="5"><?= nl2br(htmlspecialchars($m['corps'])) ?></td>
                 </tr>
                 <?php endforeach; ?>
             </tbody>


### PR DESCRIPTION
## Summary
- allow admins to delete and list all emails
- let users delete a received message
- show unread mail counter in navbar
- add an admin page to view mails

## Testing
- `php -l modele(SQL)/commun/mail.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528002d57483308ccf56266a80ce31