### PR TITLE
Enable profile update and password change

### DIFF
--- a/controleur(PHP)/traitement_profil.php
+++ b/controleur(PHP)/traitement_profil.php
@@ -1,0 +1,53 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (empty($_SESSION['Id_utilisateur'])) {
+    header('Location: /E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php');
+    exit();
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/db.php';
+$pdo = getPDO();
+
+$userId = (int) $_SESSION['Id_utilisateur'];
+
+// Retrieve current password hash
+$stmt = $pdo->prepare('SELECT mot_de_passe FROM utilisateur WHERE Id_utilisateur = ?');
+$stmt->execute([$userId]);
+$currentData = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$currentData) {
+    echo "<script>alert('Utilisateur introuvable'); window.location.href='/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php';</script>";
+    exit();
+}
+
+$nom    = trim($_POST['nom'] ?? '');
+$prenom = trim($_POST['prenom'] ?? '');
+$mail   = trim($_POST['mail'] ?? '');
+$currentPassword = $_POST['current_password'] ?? '';
+$newPassword     = $_POST['new_password'] ?? '';
+
+// Update basic info
+$stmt = $pdo->prepare('UPDATE utilisateur SET nom = ?, Prenom = ?, mail = ? WHERE Id_utilisateur = ?');
+$stmt->execute([$nom, $prenom, $mail, $userId]);
+
+// Update session values
+$_SESSION['nom'] = $nom;
+$_SESSION['Prenom'] = $prenom;
+
+// Handle password change when new password provided
+if ($newPassword !== '') {
+    // Verify current password
+    $valid = password_verify($currentPassword, $currentData['mot_de_passe']) || $currentPassword === $currentData['mot_de_passe'];
+    if (!$valid) {
+        echo "<script>alert('Mot de passe actuel incorrect'); window.history.back();</script>";
+        exit();
+    }
+    $hash = password_hash($newPassword, PASSWORD_DEFAULT);
+    $stmt = $pdo->prepare('UPDATE utilisateur SET mot_de_passe = ? WHERE Id_utilisateur = ?');
+    $stmt->execute([$hash, $userId]);
+}
+
+echo "<script>alert('Profil mis à jour'); window.location.href='/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/profil.php';</script>";
+?>

--- a/vue(HTML)/commun/profil.php
+++ b/vue(HTML)/commun/profil.php
@@ -39,11 +39,20 @@ if (!$user) {
 <div class="container">
     <h1>Mon Profil</h1>
     <div class="card">
-        <p><strong>Nom :</strong> <?= htmlspecialchars($user['nom']) ?></p>
-        <p><strong>Prénom :</strong> <?= htmlspecialchars($user['Prenom']) ?></p>
-        <p><strong>Email :</strong> <?= htmlspecialchars($user['mail']) ?></p>
-
-
+        <form method="POST" action="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/controleur(PHP)/traitement_profil.php">
+            <label>Nom</label>
+            <input type="text" name="nom" value="<?= htmlspecialchars($user['nom']) ?>" required><br>
+            <label>Prénom</label>
+            <input type="text" name="prenom" value="<?= htmlspecialchars($user['Prenom']) ?>" required><br>
+            <label>Mail</label>
+            <input type="email" name="mail" value="<?= htmlspecialchars($user['mail']) ?>" required><br>
+            <hr>
+            <label>Mot de passe actuel</label>
+            <input type="password" name="current_password"><br>
+            <label>Nouveau mot de passe</label>
+            <input type="password" name="new_password"><br>
+            <input type="submit" value="Mettre à jour">
+        </form>
     </div>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- add profile update controller
- allow editing name, firstname and email in profile page
- require current password before updating password

## Testing
- `php -l controleur(PHP)/traitement_profil.php`
- `php -l vue(HTML)/commun/profil.php`


------
https://chatgpt.com/codex/tasks/task_e_6852885ff91c83308dc7360ffc99606f