### PR TITLE
Change date display format

### DIFF
--- a/include(redondance)/utils.php
+++ b/include(redondance)/utils.php
@@ -1,0 +1,9 @@
+<?php
+function formatDatetimeFr(string $datetime): string {
+    $timestamp = strtotime($datetime);
+    if ($timestamp === false) {
+        return $datetime;
+    }
+    return date('d/m/Y à H\hi', $timestamp);
+}
+?>

--- a/vue(HTML)/admin/mails.php
+++ b/vue(HTML)/admin/mails.php
@@ -9,6 +9,7 @@ if (empty($_SESSION['isAdmin']) || $_SESSION['isAdmin'] != 1) {
 
 require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/mail.php';
 $pdo = getPDO();
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/utils.php';
 
 if (isset($_GET['delete'])) {
     deleteMessage($pdo, (int)$_GET['delete']);
@@ -51,7 +52,7 @@ $mails = getAllMessages($pdo);
                     <td><?= htmlspecialchars($m['expediteur_prenom'] . ' ' . $m['expediteur_nom']) ?></td>
                     <td><?= htmlspecialchars($m['destinataire_prenom'] . ' ' . $m['destinataire_nom']) ?></td>
                     <td><?= htmlspecialchars($m['sujet'] ?? '') ?></td>
-                    <td><?= htmlspecialchars($m['date_envoi']) ?></td>
+                    <td><?= htmlspecialchars(formatDatetimeFr($m['date_envoi'])) ?></td>
                     <td><?= $m['lu'] ? 'Oui' : 'Non' ?></td>
                     <td>
                         <a class="button" href="vue(HTML)/admin/mails.php?delete=<?= $m['Id_mail'] ?>" onclick="return confirm('Supprimer ?');">Supprimer</a>

--- a/vue(HTML)/admin/reservations.php
+++ b/vue(HTML)/admin/reservations.php
@@ -8,6 +8,7 @@ if (empty($_SESSION['isAdmin']) || $_SESSION['isAdmin'] != 1) {
 }
 require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
 $pdo = getDbConnection();
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/utils.php';
 
 // Delete reservation
 if (isset($_GET['delete'])) {
@@ -87,8 +88,8 @@ $reservations = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
     <?php foreach ($reservations as $r): ?>
         <tr>
             <td><?= htmlspecialchars($r['nom_terrain']) ?></td>
-            <td><?= htmlspecialchars($r['date_debut']) ?></td>
-            <td><?= htmlspecialchars($r['date_fin']) ?></td>
+            <td><?= htmlspecialchars(formatDatetimeFr($r['date_debut'])) ?></td>
+            <td><?= htmlspecialchars(formatDatetimeFr($r['date_fin'])) ?></td>
             <td><?= htmlspecialchars($r['nom'] . ' ' . $r['Prenom']) ?></td>
             <td><?= htmlspecialchars($r['nbr_util']) ?></td>
             <td>

--- a/vue(HTML)/commun/historique.php
+++ b/vue(HTML)/commun/historique.php
@@ -10,6 +10,7 @@ if (empty($_SESSION['Id_utilisateur']) || (!empty($_SESSION['isAdmin']) && $_SES
 
 require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
 $pdo = getDbConnection();
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/utils.php';
 
 $userId = $_SESSION['Id_utilisateur'];
 // Handle reservation cancellation
@@ -49,8 +50,8 @@ $reservations = getReservationsForUser($pdo, $userId);
             <?php foreach ($reservations as $r): ?>
                 <tr>
                     <td><?= htmlspecialchars($r['nom_terrain']) ?></td>
-                    <td><?= htmlspecialchars($r['date_debut']) ?></td>
-                    <td><?= htmlspecialchars($r['date_fin']) ?></td>
+                    <td><?= htmlspecialchars(formatDatetimeFr($r['date_debut'])) ?></td>
+                    <td><?= htmlspecialchars(formatDatetimeFr($r['date_fin'])) ?></td>
                     <td><?= htmlspecialchars($r['nbr_util']) ?></td>
                     <td>
                         <a class="button" href="vue(HTML)/commun/historique.php?delete=<?= urlencode($r['Id_reservation']) ?>" onclick="return confirm('Annuler cette réservation ?');">Annuler</a>

--- a/vue(HTML)/commun/mailbox.php
+++ b/vue(HTML)/commun/mailbox.php
@@ -9,6 +9,7 @@ if (empty($_SESSION['Id_utilisateur'])) {
 
 require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/mail.php';
 $pdo = getPDO();
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/utils.php';
 $userId = (int)$_SESSION['Id_utilisateur'];
 
 // Mark as read
@@ -68,7 +69,7 @@ $users = getAllUsers($pdo);
                 <tr>
                     <td><?= htmlspecialchars($m['Prenom'] . ' ' . $m['nom']) ?></td>
                     <td><?= htmlspecialchars($m['sujet'] ?? '') ?></td>
-                    <td><?= htmlspecialchars($m['date_envoi']) ?></td>
+                    <td><?= htmlspecialchars(formatDatetimeFr($m['date_envoi'])) ?></td>
                     <td>
                         <?= $m['lu'] ? 'Oui' : 'Non' ?>
                         <?php if (!$m['lu']): ?>

--- a/vue(HTML)/commun/reserver.php
+++ b/vue(HTML)/commun/reserver.php
@@ -8,6 +8,7 @@ if (empty($_SESSION['Id_utilisateur'])) {
 }
 require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/reservation.php';
 $pdo = getDbConnection();
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/utils.php';
 
 $terrainId = $_GET['id'] ?? '';
 if (!$terrainId) {
@@ -64,7 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <p>Créneaux déjà réservés :</p>
     <ul>
     <?php foreach ($existingReservations as $resa): ?>
-        <li>Du <?= htmlspecialchars($resa['date_debut']) ?> au <?= htmlspecialchars($resa['date_fin']) ?></li>
+        <li>Du <?= htmlspecialchars(formatDatetimeFr($resa['date_debut'])) ?> au <?= htmlspecialchars(formatDatetimeFr($resa['date_fin'])) ?></li>
     <?php endforeach; ?>
     </ul>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add `formatDatetimeFr` helper to display readable dates
- include helper and format dates on reservation, mail, and history pages

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685406392ffc83308b7046505ee77391