### PR TITLE
Add user feedback page

### DIFF
--- a/controleur(PHP)/traitement_avis.php
+++ b/controleur(PHP)/traitement_avis.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $note = (int)($_POST['note'] ?? 0);
+    $comment = trim($_POST['comment'] ?? '');
+    $name = '';
+    if (!empty($_SESSION['Prenom']) || !empty($_SESSION['nom'])) {
+        $name = trim(($_SESSION['Prenom'] ?? '') . ' ' . ($_SESSION['nom'] ?? ''));
+    } else {
+        $name = 'Visiteur';
+    }
+
+    $to = 'ludorouge7@gmail.com';
+    $subject = 'Nouvel avis sur le site';
+    $message = "Utilisateur: $name\n";
+    $message .= "Note: $note/5\n\n";
+    $message .= $comment;
+    $headers = "From: noreply@example.com\r\n";
+
+    if (mail($to, $subject, $message, $headers)) {
+        echo "<script>alert('Merci pour votre avis !'); window.location.href='/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/accueil.php';</script>";
+    } else {
+        $logDir = __DIR__ . '/../logs';
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0777, true);
+        }
+        $logMessage = date('c') . " | $name ($note/5) : " . str_replace("\n", ' ', $comment) . PHP_EOL;
+        file_put_contents($logDir . '/avis.log', $logMessage, FILE_APPEND);
+        echo "<script>alert('Erreur lors de l\'envoi de l\'avis. Votre avis a été enregistré.'); window.history.back();</script>";
+    }
+}
+?>

--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -32,6 +32,7 @@ if (!empty($_SESSION['Id_utilisateur'])) {
         <?php endif; ?>
 
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/quisommesnous.php">Qui sommes-nous ?</a>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/avis.php">Donner votre avis</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/profil.php">Mon Profil</a>
 
     </div>

--- a/vue(HTML)/commun/avis.php
+++ b/vue(HTML)/commun/avis.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Laisser un avis</title>
+    <base href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/">
+    <link rel="stylesheet" type="text/css" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<div class="container">
+    <h1>Laisser un avis</h1>
+    <div class="card">
+        <form action="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/controleur(PHP)/traitement_avis.php" method="POST">
+            <label for="note">Note</label>
+            <select id="note" name="note" required>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5" selected>5</option>
+            </select>
+            <label for="comment">Votre avis</label>
+            <textarea id="comment" name="comment" rows="4" required></textarea>
+            <input type="submit" value="Envoyer">
+        </form>
+    </div>
+</div>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable users to submit site feedback via a new form
- send/record the feedback in `traitement_avis.php`
- link new page from the navbar

## Testing
- `php -l vue(HTML)/commun/avis.php`
- `php -l controleur(PHP)/traitement_avis.php`

------
https://chatgpt.com/codex/tasks/task_e_68541b085c30833094c5d351e283b4f4