### PR TITLE
Add database-backed reviews

### DIFF
--- a/controleur(PHP)/traitement_avis.php
+++ b/controleur(PHP)/traitement_avis.php
@@ -1,16 +1,26 @@
 <?php
 session_start();
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/avis.php';
+$pdo = getPDO();
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $note = (int)($_POST['note'] ?? 0);
+    $note    = (int)($_POST['note'] ?? 0);
     $comment = trim($_POST['comment'] ?? '');
-    $name = '';
+    $name    = '';
+
     if (!empty($_SESSION['Prenom']) || !empty($_SESSION['nom'])) {
         $name = trim(($_SESSION['Prenom'] ?? '') . ' ' . ($_SESSION['nom'] ?? ''));
     } else {
         $name = 'Visiteur';
     }
 
-    $to = 'ludorouge7@gmail.com';
+    $userId = isset($_SESSION['Id_utilisateur']) ? (int)$_SESSION['Id_utilisateur'] : 0;
+
+    // Enregistrement de l'avis dans la base
+    addAvis($pdo, $userId, $note, $comment);
+
+    $to      = 'ludorouge7@gmail.com';
     $subject = 'Nouvel avis sur le site';
     $message = "Utilisateur: $name\n";
     $message .= "Note: $note/5\n\n";

--- a/modele(SQL)/commun/avis.php
+++ b/modele(SQL)/commun/avis.php
@@ -1,0 +1,29 @@
+<?php
+require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/db.php');
+
+/**
+ * Enregistre un avis utilisateur en base.
+ *
+ * @param PDO $pdo          Connexion PDO
+ * @param int $utilisateur  Identifiant de l'utilisateur (0 si visiteur)
+ * @param int $note         Note de 1 a 5
+ * @param string $comment   Texte de l'avis
+ *
+ * @return bool             Succès de l'insertion
+ */
+function addAvis(PDO $pdo, int $utilisateur, int $note, string $comment): bool {
+    $stmt = $pdo->prepare('INSERT INTO avis (utilisateur_id, note, avis) VALUES (?, ?, ?)');
+    return $stmt->execute([$utilisateur, $note, $comment]);
+}
+
+/**
+ * Récupère les avis stockés par ordre chronologique décroissant.
+ *
+ * @param PDO $pdo  Connexion PDO
+ * @return array    Liste des avis avec informations utilisateur
+ */
+function getAvis(PDO $pdo): array {
+    $sql = 'SELECT a.*, u.Prenom, u.nom FROM avis a LEFT JOIN utilisateur u ON a.utilisateur_id = u.Id_utilisateur ORDER BY a.created_at DESC';
+    return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+}
+?>

--- a/tablepetanque.sql
+++ b/tablepetanque.sql
@@ -39,6 +39,23 @@ CREATE TABLE IF NOT EXISTS `evenement` (
 
 -- --------------------------------------------------------
 --
+-- Structure de la table `avis`
+--
+
+DROP TABLE IF EXISTS `avis`;
+CREATE TABLE IF NOT EXISTS `avis` (
+  `id_avis` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
+  `utilisateur_id` int NOT NULL,
+  `note` smallint NOT NULL,
+  `avis` text NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id_avis`),
+  UNIQUE KEY `id_avis` (`id_avis`),
+  KEY `fk_utilisateur` (`utilisateur_id`)
+) ;
+
+-- --------------------------------------------------------
+--
 -- Structure de la table `mail`
 --
 

--- a/vue(HTML)/commun/avis.php
+++ b/vue(HTML)/commun/avis.php
@@ -8,7 +8,12 @@
     <link rel="stylesheet" type="text/css" href="css/index.css">
 </head>
 <body>
-<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<?php 
+require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php');
+require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/avis.php');
+$pdo = getPDO();
+$avisList = getAvis($pdo);
+?>
 <div class="container">
     <h1>Laisser un avis</h1>
     <div class="card">
@@ -26,6 +31,17 @@
             <input type="submit" value="Envoyer">
         </form>
     </div>
+
+    <?php if (!empty($avisList)): ?>
+    <h2>Derniers avis</h2>
+    <?php foreach ($avisList as $avis): ?>
+        <div class="avis-item">
+            <strong><?= htmlspecialchars(trim(($avis['Prenom'] ?? '') . ' ' . ($avis['nom'] ?? 'Visiteur'))) ?></strong>
+            <span>(<?= (int)$avis['note'] ?>/5)</span>
+            <p><?= htmlspecialchars($avis['avis']) ?></p>
+        </div>
+    <?php endforeach; ?>
+    <?php endif; ?>
 </div>
 <?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
 </body>


### PR DESCRIPTION
## Summary
- store reviews using new avis table
- list all reviews on avis.php
- keep email notification fallback when submitting reviews
- include avis table in initial SQL schema

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541ce7533c8330bbfa70eafdb605c4