### PR TITLE
Ajout de la gestion admin des avis

### DIFF
--- a/include(redondance)/navbar.php
+++ b/include(redondance)/navbar.php
@@ -28,6 +28,7 @@ if (!empty($_SESSION['Id_utilisateur'])) {
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/utilisateurs.php">Gérer les utilisateurs</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/reservations.php">Gérer les réservations</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/mails.php">Gérer les mails</a>
+        <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/avis.php">Gérer les avis</a>
         <a href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/admin/statistiques.php">Statistiques</a>
         <?php endif; ?>
 

--- a/modele(SQL)/commun/avis.php
+++ b/modele(SQL)/commun/avis.php
@@ -26,4 +26,46 @@ function getAvis(PDO $pdo): array {
     $sql = 'SELECT a.*, u.Prenom, u.nom FROM avis a LEFT JOIN utilisateur u ON a.utilisateur_id = u.Id_utilisateur ORDER BY a.created_at DESC';
     return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
 }
+
+/**
+ * Récupère un avis par son identifiant.
+ *
+ * @param PDO $pdo  Connexion PDO
+ * @param int $id   Identifiant de l'avis
+ *
+ * @return array|false Les données de l'avis ou false si introuvable
+ */
+function getAvisById(PDO $pdo, int $id) {
+    $stmt = $pdo->prepare('SELECT a.*, u.Prenom, u.nom FROM avis a LEFT JOIN utilisateur u ON a.utilisateur_id = u.Id_utilisateur WHERE id_avis = ?');
+    $stmt->execute([$id]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+/**
+ * Met à jour un avis existant.
+ *
+ * @param PDO    $pdo     Connexion PDO
+ * @param int    $id      Identifiant de l'avis
+ * @param int    $note    Nouvelle note
+ * @param string $comment Nouveau texte de l'avis
+ *
+ * @return bool  Succès de la mise à jour
+ */
+function updateAvis(PDO $pdo, int $id, int $note, string $comment): bool {
+    $stmt = $pdo->prepare('UPDATE avis SET note = ?, avis = ? WHERE id_avis = ?');
+    return $stmt->execute([$note, $comment, $id]);
+}
+
+/**
+ * Supprime un avis.
+ *
+ * @param PDO $pdo Connexion PDO
+ * @param int $id  Identifiant de l'avis
+ *
+ * @return bool    Succès de la suppression
+ */
+function deleteAvis(PDO $pdo, int $id): bool {
+    $stmt = $pdo->prepare('DELETE FROM avis WHERE id_avis = ?');
+    return $stmt->execute([$id]);
+}
 ?>

--- a/vue(HTML)/admin/avis.php
+++ b/vue(HTML)/admin/avis.php
@@ -1,0 +1,98 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (empty($_SESSION['isAdmin']) || $_SESSION['isAdmin'] != 1) {
+    header('Location: /E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/login.php');
+    exit();
+}
+
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/modele(SQL)/commun/avis.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/utils.php';
+$pdo = getPDO();
+
+if (isset($_GET['delete'])) {
+    deleteAvis($pdo, (int)$_GET['delete']);
+    header('Location: avis.php');
+    exit();
+}
+
+$editAvis = null;
+if (isset($_GET['edit'])) {
+    $editAvis = getAvisById($pdo, (int)$_GET['edit']);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_POST['action'] === 'update') {
+    $id = (int)$_POST['id'];
+    $note = (int)$_POST['note'];
+    $comment = trim($_POST['comment']);
+    updateAvis($pdo, $id, $note, $comment);
+    header('Location: avis.php');
+    exit();
+}
+
+$avisList = getAvis($pdo);
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestion des avis</title>
+    <base href="/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/">
+    <link rel="stylesheet" href="css/index.css">
+</head>
+<body>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/navbar.php'); ?>
+<div class="container">
+    <h1>Gestion des avis</h1>
+    <?php if ($editAvis): ?>
+    <h2>Modifier un avis</h2>
+    <div class="card">
+        <form method="POST" action="">
+            <input type="hidden" name="action" value="update">
+            <input type="hidden" name="id" value="<?= htmlspecialchars($editAvis['id_avis']) ?>">
+            <label>Note</label>
+            <select name="note" required>
+                <?php for ($i = 1; $i <= 5; $i++): ?>
+                    <option value="<?= $i ?>" <?= $editAvis['note'] == $i ? 'selected' : '' ?>><?= $i ?></option>
+                <?php endfor; ?>
+            </select><br>
+            <label>Avis</label>
+            <textarea name="comment" rows="4" required><?= htmlspecialchars($editAvis['avis']) ?></textarea><br>
+            <button class="button" type="submit">Mettre à jour</button>
+        </form>
+    </div>
+    <?php endif; ?>
+    <div class="card">
+        <table>
+            <thead>
+                <tr>
+                    <th>Utilisateur</th>
+                    <th>Note</th>
+                    <th>Avis</th>
+                    <th>Date</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($avisList as $a): ?>
+                <tr>
+                    <td><?= htmlspecialchars(trim(($a['Prenom'] ?? '') . ' ' . ($a['nom'] ?? 'Visiteur'))) ?></td>
+                    <td><?= (int)$a['note'] ?>/5</td>
+                    <td><?= htmlspecialchars($a['avis']) ?></td>
+                    <td><?= htmlspecialchars(formatDatetimeFr($a['created_at'])) ?></td>
+                    <td>
+                        <a class="button" href="vue(HTML)/admin/avis.php?delete=<?= $a['id_avis'] ?>" onclick="return confirm('Supprimer ?');">Supprimer</a>
+                        |
+                        <a class="button" href="vue(HTML)/admin/avis.php?edit=<?= $a['id_avis'] ?>">Modifier</a>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>
+<?php require_once($_SERVER['DOCUMENT_ROOT'] . '/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/include(redondance)/footer.php'); ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- permettre la modification et la suppression des avis
- ajouter une page d'administration pour gérer les avis
- afficher le lien "Gérer les avis" dans la barre de navigation

## Testing
- `php -l modele(SQL)/commun/avis.php`
- `php -l vue(HTML)/admin/avis.php`
- `php -l include(redondance)/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_68541e75803c8330a287d12a0018d483