### PR TITLE
Remove error alert on review submission

### DIFF
--- a/controleur(PHP)/traitement_avis.php
+++ b/controleur(PHP)/traitement_avis.php
@@ -36,7 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         $logMessage = date('c') . " | $name ($note/5) : " . str_replace("\n", ' ', $comment) . PHP_EOL;
         file_put_contents($logDir . '/avis.log', $logMessage, FILE_APPEND);
-        echo "<script>alert('Erreur lors de l\'envoi de l\'avis. Votre avis a été enregistré.'); window.history.back();</script>";
+        echo "<script>alert('Merci pour votre avis !'); window.location.href='/E5_petanque_MVC/LA_PETANQUE_LA_VRAI/vue(HTML)/commun/accueil.php';</script>";
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- tweak avis handling to show success message even if mail fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854211868fc8330acec8ca2e9a2fbe1